### PR TITLE
Pin the toolchain to 1.97.1 as the single source of truth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust stable + wasm target
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+      # No toolchain action: rustup resolves the pinned version, components and the
+      # wasm32 target from rust-toolchain.toml, so the released binary is built with the
+      # same compiler CI tested against.
 
       - name: Rust build cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,17 +10,16 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-# Every job uses stable, matching rust-toolchain.toml and deploy.yml. An explicit
-# nightly here overrides that pin via RUSTUP_TOOLCHAIN, and nightly rustfmt formats
-# differently from the stable one used locally, so `cargo fmt --check` disagrees
-# with a locally formatted tree.
+# No job names a toolchain. rustup resolves it from rust-toolchain.toml, which pins an
+# exact version and the rustfmt/clippy components, so CI and a developer machine run the
+# same compiler and the same lint set. Naming one here (even @stable) sets
+# RUSTUP_TOOLCHAIN and silently overrides that pin.
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --features ssr
@@ -30,9 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
       - name: Enforce formatting
         run: cargo fmt --check
 
@@ -41,9 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
       - uses: Swatinem/rust-cache@v2
       # --all-targets so test code is linted too. ssr is the default feature, but
       # naming it keeps the command honest about what is being checked.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,16 @@
+# Single source of truth for the toolchain: local builds, CI and the release build all
+# resolve it from here, so they cannot drift apart. Nothing in .github/workflows names a
+# toolchain, deliberately, so this file is the only place to edit.
+#
+# Pinned to an exact version rather than "stable". With a channel pin, a machine that has
+# not run `rustup update` recently gets an older clippy than the CI runner's, so lints
+# exist in CI that cannot be reproduced locally and a branch passes every local check and
+# then fails CI.
+#
+# Bumping is deliberate: change the version, run `cargo fmt` and
+# `cargo clippy --features ssr --all-targets -- -D warnings`, fix what the newer lints
+# find, and commit that as its own change.
 [toolchain]
-channel = "stable"
+channel = "1.97.1"
+components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
The toml now pins an exact version plus the rustfmt/clippy components, and no workflow names a toolchain. deploy.yml included, so the released binary is built by the compiler CI tested against